### PR TITLE
Add persistence and retrieval for auth identity hints

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -14,6 +14,7 @@ import {
 } from "../utils/api"
 import {
   clearStoredAccessToken,
+  clearStoredAuthIdentityHint,
   persistAuthIdentityHint,
   persistAccessToken,
   readStoredAccessToken,
@@ -79,6 +80,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     clearRuntimeBearerToken()
     clearStoredAccessToken()
     clearStoredCsrfToken()
+    clearStoredAuthIdentityHint()
     setIsAuthenticated(false)
     setToken(null)
   }, [])
@@ -163,7 +165,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       clearRuntimeBearerToken()
       clearStoredAccessToken()
       clearStoredCsrfToken()
-      persistAuthIdentityHint({ organizationSlug, apartment, block })
+      clearStoredAuthIdentityHint()
       const loginResult = await loginMutate({ organizationSlug, apartment, block, password })
       if (typeof loginResult?.access_token === "string" && loginResult.access_token.length > 0) {
         persistAccessToken(loginResult.access_token)
@@ -190,6 +192,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (!profileResponse?.user) {
         throw new Error("Não foi possível confirmar a sessão autenticada")
       }
+      persistAuthIdentityHint({ organizationSlug, apartment, block })
       setToken(COOKIE_SESSION_TOKEN)
       setIsAuthenticated(true)
       setIsAuthResolved(true)
@@ -200,6 +203,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       clearRuntimeBearerToken()
       clearStoredAccessToken()
       clearStoredCsrfToken()
+      clearStoredAuthIdentityHint()
       setIsAuthenticated(false)
       setToken(null)
       setIsAuthResolved(true)

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -14,6 +14,7 @@ import {
 } from "../utils/api"
 import {
   clearStoredAccessToken,
+  persistAuthIdentityHint,
   persistAccessToken,
   readStoredAccessToken,
   stripAccessTokenFromUrl,
@@ -162,6 +163,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       clearRuntimeBearerToken()
       clearStoredAccessToken()
       clearStoredCsrfToken()
+      persistAuthIdentityHint({ organizationSlug, apartment, block })
       const loginResult = await loginMutate({ organizationSlug, apartment, block, password })
       if (typeof loginResult?.access_token === "string" && loginResult.access_token.length > 0) {
         persistAccessToken(loginResult.access_token)

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { clearRuntimeBearerToken, fetchWithAuthHandling, setRuntimeBearerToken } from "./api"
-import { clearStoredAccessToken, persistAccessToken } from "./auth-storage"
+import { clearStoredAccessToken, clearStoredAuthIdentityHint, persistAccessToken, persistAuthIdentityHint } from "./auth-storage"
 
 describe("fetchWithAuthHandling runtime bearer fallback", () => {
   let fetchMock: ReturnType<typeof vi.fn>
@@ -8,6 +8,7 @@ describe("fetchWithAuthHandling runtime bearer fallback", () => {
   beforeEach(() => {
     clearRuntimeBearerToken()
     clearStoredAccessToken()
+    clearStoredAuthIdentityHint()
     fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       return new Response(JSON.stringify({ ok: true, headers: Object.fromEntries(new Headers(init?.headers).entries()) }), {
         status: 200,
@@ -20,6 +21,7 @@ describe("fetchWithAuthHandling runtime bearer fallback", () => {
   afterEach(() => {
     clearRuntimeBearerToken()
     clearStoredAccessToken()
+    clearStoredAuthIdentityHint()
     vi.unstubAllGlobals()
   })
 
@@ -92,5 +94,18 @@ describe("fetchWithAuthHandling runtime bearer fallback", () => {
     const init = fetchMock.mock.calls[0][1] as RequestInit
     const headers = new Headers(init.headers)
     expect(headers.get("Authorization")).toBeNull()
+  })
+
+  it("attaches apartment identity hints when available", async () => {
+    persistAuthIdentityHint({ organizationSlug: "seuze", apartment: "1201", block: 1 })
+
+    await fetchWithAuthHandling("https://example.com/protected")
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get("X-Organization-Slug-Hint")).toBe("seuze")
+    expect(headers.get("X-User-Apartment-Hint")).toBe("1201")
+    expect(headers.get("X-User-Block-Hint")).toBe("1")
   })
 })

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -108,4 +108,48 @@ describe("fetchWithAuthHandling runtime bearer fallback", () => {
     expect(headers.get("X-User-Apartment-Hint")).toBe("1201")
     expect(headers.get("X-User-Block-Hint")).toBe("1")
   })
+
+  it("does not attach identity hint headers when hint is absent", async () => {
+    await fetchWithAuthHandling("https://example.com/protected")
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get("X-Organization-Slug-Hint")).toBeNull()
+    expect(headers.get("X-User-Apartment-Hint")).toBeNull()
+    expect(headers.get("X-User-Block-Hint")).toBeNull()
+  })
+
+  it("does not attach identity hint headers after hint is cleared", async () => {
+    persistAuthIdentityHint({ organizationSlug: "seuze", apartment: "1201", block: 1 })
+    clearStoredAuthIdentityHint()
+
+    await fetchWithAuthHandling("https://example.com/protected")
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get("X-Organization-Slug-Hint")).toBeNull()
+    expect(headers.get("X-User-Apartment-Hint")).toBeNull()
+    expect(headers.get("X-User-Block-Hint")).toBeNull()
+  })
+
+  it("does not override explicit identity hint headers provided in options", async () => {
+    persistAuthIdentityHint({ organizationSlug: "seuze", apartment: "1201", block: 1 })
+
+    await fetchWithAuthHandling("https://example.com/protected", {
+      headers: {
+        "X-Organization-Slug-Hint": "explicit-org",
+        "X-User-Apartment-Hint": "explicit-apt",
+        "X-User-Block-Hint": "explicit-block",
+      },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get("X-Organization-Slug-Hint")).toBe("explicit-org")
+    expect(headers.get("X-User-Apartment-Hint")).toBe("explicit-apt")
+    expect(headers.get("X-User-Block-Hint")).toBe("explicit-block")
+  })
 })

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,5 @@
 import { authDebug, authError, sanitizeForLog, stripSensitiveQueryParams } from "./auth-logger"
-import { readStoredAccessToken } from "./auth-storage"
+import { readStoredAccessToken, readStoredAuthIdentityHint } from "./auth-storage"
 import { isStateChangingMethod, readCsrfToken } from "./csrf"
 
 let unauthorizedSignalSent = false
@@ -52,8 +52,18 @@ export const fetchWithAuthHandling = async (url: string, options: RequestInit = 
   const method = options.method || "GET"
   const headers = new Headers(options.headers || {})
   const effectiveBearerToken = runtimeBearerToken || readStoredAccessToken()
+  const identityHint = readStoredAuthIdentityHint()
   if (!headers.has("Authorization") && effectiveBearerToken) {
     headers.set("Authorization", `Bearer ${effectiveBearerToken}`)
+  }
+  if (identityHint?.organizationSlug && !headers.has("X-Organization-Slug-Hint")) {
+    headers.set("X-Organization-Slug-Hint", identityHint.organizationSlug)
+  }
+  if (identityHint?.apartment && !headers.has("X-User-Apartment-Hint")) {
+    headers.set("X-User-Apartment-Hint", identityHint.apartment)
+  }
+  if (typeof identityHint?.block === "number" && Number.isFinite(identityHint.block) && !headers.has("X-User-Block-Hint")) {
+    headers.set("X-User-Block-Hint", `${identityHint.block}`)
   }
 
   if (isStateChangingMethod(method)) {

--- a/src/utils/auth-storage.test.ts
+++ b/src/utils/auth-storage.test.ts
@@ -101,4 +101,58 @@ describe("auth storage", () => {
       block: 2,
     })
   })
+
+  it("normalizes organizationSlug using normalizeOrganizationSlug on persist", () => {
+    persistAuthIdentityHint({ organizationSlug: "  Séuze Cond  ", apartment: "101", block: 1 })
+
+    const hint = readStoredAuthIdentityHint()
+    expect(hint?.organizationSlug).toBe("seuze-cond")
+  })
+
+  it("trims and truncates apartment hint string", () => {
+    const longApartment = "A".repeat(100)
+    persistAuthIdentityHint({ apartment: `  ${longApartment}  ` })
+
+    const hint = readStoredAuthIdentityHint()
+    expect(hint?.apartment).toBe("A".repeat(64))
+  })
+
+  it("strips control characters from hint strings", () => {
+    persistAuthIdentityHint({ organizationSlug: "my\nslug", apartment: "101\r" })
+
+    const hint = readStoredAuthIdentityHint()
+    expect(hint?.organizationSlug).toBe("myslug")
+    expect(hint?.apartment).toBe("101")
+  })
+
+  it("treats non-string organizationSlug as undefined", () => {
+    persistAuthIdentityHint({ organizationSlug: undefined, apartment: "101", block: 1 })
+
+    const hint = readStoredAuthIdentityHint()
+    expect(hint?.organizationSlug).toBeUndefined()
+  })
+
+  it("treats empty organizationSlug after normalization as undefined", () => {
+    persistAuthIdentityHint({ organizationSlug: "  \n\r  " })
+
+    const hint = readStoredAuthIdentityHint()
+    expect(hint?.organizationSlug).toBeUndefined()
+  })
+
+  it("returns null and clears storage when stored JSON is malformed", () => {
+    storage.setItem("auth_identity_hint", "not-valid-json{")
+
+    const result = readStoredAuthIdentityHint()
+
+    expect(result).toBeNull()
+    expect(storage.removeItem).toHaveBeenCalledWith("auth_identity_hint")
+  })
+
+  it("clearStoredAuthIdentityHint removes hint from memory and sessionStorage", () => {
+    persistAuthIdentityHint({ organizationSlug: "seuze", apartment: "101", block: 1 })
+    clearStoredAuthIdentityHint()
+
+    expect(readStoredAuthIdentityHint()).toBeNull()
+    expect(storage.getItem("auth_identity_hint")).toBeNull()
+  })
 })

--- a/src/utils/auth-storage.test.ts
+++ b/src/utils/auth-storage.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
+  clearStoredAuthIdentityHint,
   clearStoredAccessToken,
+  persistAuthIdentityHint,
   persistAccessToken,
+  readStoredAuthIdentityHint,
   readStoredAccessToken,
   stripAccessTokenFromUrl,
 } from "./auth-storage"
@@ -45,6 +48,7 @@ describe("auth storage", () => {
     vi.stubGlobal("document", { title: "Test Title" })
     vi.stubGlobal("sessionStorage", storage)
     clearStoredAccessToken()
+    clearStoredAuthIdentityHint()
   })
 
   afterEach(() => {
@@ -86,5 +90,15 @@ describe("auth storage", () => {
 
     expect(stripAccessTokenFromUrl()).toBe(true)
     expect(replaceState).toHaveBeenCalledWith({}, "Test Title", "/home?tab=1")
+  })
+
+  it("persists and reads auth identity hint", () => {
+    persistAuthIdentityHint({ organizationSlug: "seuze", apartment: "101", block: 2 })
+
+    expect(readStoredAuthIdentityHint()).toEqual({
+      organizationSlug: "seuze",
+      apartment: "101",
+      block: 2,
+    })
   })
 })

--- a/src/utils/auth-storage.ts
+++ b/src/utils/auth-storage.ts
@@ -57,7 +57,7 @@ const normalizeHintBlock = (value: unknown): number | undefined => {
 
 export const persistAuthIdentityHint = (hint: AuthIdentityHint): void => {
   const rawSlug = normalizeHintString(hint.organizationSlug)
-  const normalizedSlug = rawSlug ? normalizeOrganizationSlug(rawSlug) || undefined : undefined
+  const normalizedSlug = rawSlug ? (normalizeOrganizationSlug(rawSlug) || undefined) : undefined
   const normalizedHint: AuthIdentityHint = {
     organizationSlug: normalizedSlug,
     apartment: normalizeHintString(hint.apartment),
@@ -79,7 +79,7 @@ export const readStoredAuthIdentityHint = (): AuthIdentityHint | null => {
   try {
     const parsed = JSON.parse(raw) as AuthIdentityHint
     const rawSlug = normalizeHintString(parsed.organizationSlug)
-    const normalizedSlug = rawSlug ? normalizeOrganizationSlug(rawSlug) || undefined : undefined
+    const normalizedSlug = rawSlug ? (normalizeOrganizationSlug(rawSlug) || undefined) : undefined
     const normalizedHint: AuthIdentityHint = {
       organizationSlug: normalizedSlug,
       apartment: normalizeHintString(parsed.apartment),

--- a/src/utils/auth-storage.ts
+++ b/src/utils/auth-storage.ts
@@ -1,6 +1,14 @@
 const TOKEN_KEY = "access_token"
 const LEGACY_TOKEN_KEY = "token"
+const AUTH_IDENTITY_HINT_KEY = "auth_identity_hint"
 let inMemoryAccessToken: string | null = null
+let inMemoryAuthIdentityHint: AuthIdentityHint | null = null
+
+export interface AuthIdentityHint {
+  organizationSlug?: string
+  apartment?: string
+  block?: number
+}
 
 const hasStorage = (): boolean => typeof window !== "undefined" && !!window.sessionStorage
 
@@ -27,6 +35,61 @@ export const clearStoredAccessToken = (): void => {
 
   sessionStorage.removeItem(TOKEN_KEY)
   sessionStorage.removeItem(LEGACY_TOKEN_KEY)
+}
+
+const normalizeHintString = (value: unknown, maxLength = 64): string | undefined => {
+  if (typeof value !== "string") return undefined
+  const normalized = value.trim()
+  if (!normalized) return undefined
+  return normalized.slice(0, maxLength)
+}
+
+const normalizeHintBlock = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value)
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+export const persistAuthIdentityHint = (hint: AuthIdentityHint): void => {
+  const normalizedHint: AuthIdentityHint = {
+    organizationSlug: normalizeHintString(hint.organizationSlug),
+    apartment: normalizeHintString(hint.apartment),
+    block: normalizeHintBlock(hint.block),
+  }
+  inMemoryAuthIdentityHint = normalizedHint
+  if (!hasStorage()) return
+
+  sessionStorage.setItem(AUTH_IDENTITY_HINT_KEY, JSON.stringify(normalizedHint))
+}
+
+export const readStoredAuthIdentityHint = (): AuthIdentityHint | null => {
+  if (inMemoryAuthIdentityHint) return inMemoryAuthIdentityHint
+  if (!hasStorage()) return null
+
+  const raw = sessionStorage.getItem(AUTH_IDENTITY_HINT_KEY)
+  if (!raw) return null
+
+  try {
+    const parsed = JSON.parse(raw) as AuthIdentityHint
+    const normalizedHint: AuthIdentityHint = {
+      organizationSlug: normalizeHintString(parsed.organizationSlug),
+      apartment: normalizeHintString(parsed.apartment),
+      block: normalizeHintBlock(parsed.block),
+    }
+    inMemoryAuthIdentityHint = normalizedHint
+    return normalizedHint
+  } catch {
+    return null
+  }
+}
+
+export const clearStoredAuthIdentityHint = (): void => {
+  inMemoryAuthIdentityHint = null
+  if (!hasStorage()) return
+  sessionStorage.removeItem(AUTH_IDENTITY_HINT_KEY)
 }
 
 export const stripAccessTokenFromUrl = (): boolean => {

--- a/src/utils/auth-storage.ts
+++ b/src/utils/auth-storage.ts
@@ -1,3 +1,5 @@
+import { normalizeOrganizationSlug } from "./organizationSlug"
+
 const TOKEN_KEY = "access_token"
 const LEGACY_TOKEN_KEY = "token"
 const AUTH_IDENTITY_HINT_KEY = "auth_identity_hint"
@@ -39,7 +41,7 @@ export const clearStoredAccessToken = (): void => {
 
 const normalizeHintString = (value: unknown, maxLength = 64): string | undefined => {
   if (typeof value !== "string") return undefined
-  const normalized = value.trim()
+  const normalized = value.replace(/[\u0000-\u001F\u007F]/g, "").trim()
   if (!normalized) return undefined
   return normalized.slice(0, maxLength)
 }
@@ -54,8 +56,10 @@ const normalizeHintBlock = (value: unknown): number | undefined => {
 }
 
 export const persistAuthIdentityHint = (hint: AuthIdentityHint): void => {
+  const rawSlug = normalizeHintString(hint.organizationSlug)
+  const normalizedSlug = rawSlug ? normalizeOrganizationSlug(rawSlug) || undefined : undefined
   const normalizedHint: AuthIdentityHint = {
-    organizationSlug: normalizeHintString(hint.organizationSlug),
+    organizationSlug: normalizedSlug,
     apartment: normalizeHintString(hint.apartment),
     block: normalizeHintBlock(hint.block),
   }
@@ -74,14 +78,17 @@ export const readStoredAuthIdentityHint = (): AuthIdentityHint | null => {
 
   try {
     const parsed = JSON.parse(raw) as AuthIdentityHint
+    const rawSlug = normalizeHintString(parsed.organizationSlug)
+    const normalizedSlug = rawSlug ? normalizeOrganizationSlug(rawSlug) || undefined : undefined
     const normalizedHint: AuthIdentityHint = {
-      organizationSlug: normalizeHintString(parsed.organizationSlug),
+      organizationSlug: normalizedSlug,
       apartment: normalizeHintString(parsed.apartment),
       block: normalizeHintBlock(parsed.block),
     }
     inMemoryAuthIdentityHint = normalizedHint
     return normalizedHint
   } catch {
+    clearStoredAuthIdentityHint()
     return null
   }
 }


### PR DESCRIPTION
This pull request adds support for persisting and attaching user identity hints (organization slug, apartment, and block) to API requests. This enables the backend to receive additional context about the user making the request. The implementation includes utility functions for storing, retrieving, and clearing these identity hints, and ensures they are normalized before usage. Comprehensive tests are added to verify the correct behavior.

**Identity Hint Persistence and Normalization**
* Added `persistAuthIdentityHint`, `readStoredAuthIdentityHint`, and `clearStoredAuthIdentityHint` functions in `auth-storage.ts` to persist, retrieve, and clear user identity hints (organization slug, apartment, block) in session storage and memory, including normalization logic for each field. [[1]](diffhunk://#diff-ec4f3d4b9197e69b913bc36bcfead283664fdbc72b474ccd97e3a4faeed8327cR3-R11) [[2]](diffhunk://#diff-ec4f3d4b9197e69b913bc36bcfead283664fdbc72b474ccd97e3a4faeed8327cR40-R94)
* Introduced the `AuthIdentityHint` interface to define the shape of the persisted hint.

**API Request Enhancement**
* Modified `fetchWithAuthHandling` in `api.ts` to read stored identity hints and attach them as `X-Organization-Slug-Hint`, `X-User-Apartment-Hint`, and `X-User-Block-Hint` headers on outgoing requests when available. [[1]](diffhunk://#diff-005aabee8c8c23534dc0f09ba8842309697d0be3e0d481efcb71d3fd0e6dccc6L2-R2) [[2]](diffhunk://#diff-005aabee8c8c23534dc0f09ba8842309697d0be3e0d481efcb71d3fd0e6dccc6R55-R67)

**Authentication Flow Update**
* Updated the login flow in `AuthContext.tsx` to persist the user's identity hint upon login, ensuring subsequent API requests include this context. [[1]](diffhunk://#diff-18818acbefb343d45b10cdd411ea121ebbf4b9dee1824a3dc449fa1bdbbb29f9R17) [[2]](diffhunk://#diff-18818acbefb343d45b10cdd411ea121ebbf4b9dee1824a3dc449fa1bdbbb29f9R166)

**Testing**
* Added and updated tests in `auth-storage.test.ts` and `api.test.ts` to cover identity hint persistence, retrieval, clearing, and correct header attachment to API requests. [[1]](diffhunk://#diff-d5a6df9d0c881eb6e55ff962d0ae68f8b724ddde528c187f8d62314b989c6ef2R3-R7) [[2]](diffhunk://#diff-d5a6df9d0c881eb6e55ff962d0ae68f8b724ddde528c187f8d62314b989c6ef2R51) [[3]](diffhunk://#diff-d5a6df9d0c881eb6e55ff962d0ae68f8b724ddde528c187f8d62314b989c6ef2R94-R103) [[4]](diffhunk://#diff-596d0d5c9775d43daab58d91c931513a90c05bc3ede0682288932cc9b7233f1eL3-R11) [[5]](diffhunk://#diff-596d0d5c9775d43daab58d91c931513a90c05bc3ede0682288932cc9b7233f1eR24) [[6]](diffhunk://#diff-596d0d5c9775d43daab58d91c931513a90c05bc3ede0682288932cc9b7233f1eR98-R110)